### PR TITLE
Fixed 'ButtonDisabled' Text Color

### DIFF
--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -8388,7 +8388,7 @@
       </Color>
       <Color Name="ButtonDisabled">
         <Background Type="CT_RAW" Source="FF626880" />
-        <Foreground Type="CT_RAW" Source="FFC6D0F5" />
+        <Foreground Type="CT_RAW" Source="FF6C728C" />
       </Color>
       <Color Name="CallToActionButtonDisabled">
         <Background Type="CT_RAW" Source="FF626880" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -8388,7 +8388,7 @@
       </Color>
       <Color Name="ButtonDisabled">
         <Background Type="CT_RAW" Source="FFACB0BE" />
-        <Foreground Type="CT_RAW" Source="FF4C4F69" />
+        <Foreground Type="CT_RAW" Source="FFADB0BD" />
       </Color>
       <Color Name="CallToActionButtonDisabled">
         <Background Type="CT_RAW" Source="FFACB0BE" />

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -8388,7 +8388,7 @@
       </Color>
       <Color Name="ButtonDisabled">
         <Background Type="CT_RAW" Source="FF5B6078" />
-        <Foreground Type="CT_RAW" Source="FFCAD3F5" />
+        <Foreground Type="CT_RAW" Source="FF666B84" />
       </Color>
       <Color Name="CallToActionButtonDisabled">
         <Background Type="CT_RAW" Source="FF5B6078" />

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -8524,7 +8524,7 @@
       </Color>
       <Color Name="ButtonDisabled">
         <Background Type="CT_RAW" Source="FF585B70" />
-        <Foreground Type="CT_RAW" Source="FFCDD6F4" />
+        <Foreground Type="CT_RAW" Source="FF64677D" />
       </Color>
       <Color Name="CallToActionButtonDisabled">
         <Background Type="CT_RAW" Source="FF585B70" />


### PR DESCRIPTION
Fixed 'ButtonDisabled' Color.

Quickest way to view:
1. Open a project tracked via git
2. In bottom status bar, click on the active branch
3. Rick click on any branch in the popup
4. View several disabled options, text and glyph color should match other disabled elements.