### PR TITLE
Added the sticky scroll line color

### DIFF
--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -6123,8 +6123,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF303446" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF414559" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -6127,10 +6127,6 @@
         <Background Type="CT_RAW" Source="FF303446" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF414559" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5595,10 +5595,6 @@
         <Background Type="CT_RAW" Source="FFEFF1F5" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FFCCD0DA" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5591,8 +5591,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="OverviewMarginCollapsedRegion">

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -6123,8 +6123,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF24273A" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF363A4F" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -6127,10 +6127,6 @@
         <Background Type="CT_RAW" Source="FF24273A" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF363A4F" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -6072,8 +6072,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF313244" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -6076,10 +6076,6 @@
         <Background Type="CT_RAW" Source="FF1E1E2E" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF313244" />
         <Foreground Type="CT_INVALID" Source="00000000" />


### PR DESCRIPTION
Adds the correct color for the sticky scroll line introduced in the last preview release or UI refresh release

Do note that for some reason there's an opacity of 25% being applied to the hover color that I don't know how to override

This fixes issue #50

show:
![gaming](https://github.com/user-attachments/assets/f76f015b-2153-4d97-baee-c01f6a781482)

