### PR TITLE
Refresh UI support

### DIFF
--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -6123,8 +6123,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF303446" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF414559" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -988,6 +988,37 @@
         <Background Type="CT_RAW" Source="FFA2A4A5" />
       </Color>
     </Category>
+    <Category Name="EditorOverride" GUID="{656339d7-0e39-43e2-98aa-becc3f87ffa5}">
+      <Color Name="PopupBackground">
+        <!-- <Color Name="Popup"> -->
+        <Background Type="CT_RAW" Source="FF303446" />
+        <Foreground Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="PopupText">
+        <!-- ComboBoxText / Foreground -->
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="PopupBorder">
+        <!-- ToolTipBorder -->
+        <Background Type="CT_RAW" Source="FF626880" />
+      </Color>
+      <Color Name="PopupSelectedBackground">
+        <!-- ListItemBackgroundSelected -->
+        <Background Type="CT_RAW" Source="FF51576D" />
+      </Color>
+      <Color Name="PopupSelectedText">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+	  <Color Name="PopupLink">
+	  <!-- PanelHyperlinkInsideSelectionActive -->
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+	  </Color>
+	  <Color Name="PopupSubtleText">
+	  <!-- PanelHyperlinkInsideSelection -->
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+	  </Color>
+    </Category>
     <Category Name="Command Window" GUID="{ee1be240-4e81-4beb-8eea-54322b6b1bf5}">
       <Color Name="Plain Text">
         <Background Type="CT_RAW" Source="FF19171C" />
@@ -10126,6 +10157,160 @@
       </Color>
     </Category>
     <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="SolidBackgroundFillTertiary">
+        <!-- Explorer header and active tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF232634" />
+      </Color>
+      <!-- new color text (They renamed it) -->
+      <Color Name="TextFillPrimary">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="TextFillSecondary">
+        <!-- FileTabInactiveText -->
+        <!-- Example: An inactive tab -->
+        <Background Type="CT_RAW" Source="FF737994" />
+      </Color>
+      <Color Name="TextFillTertiary">
+        <!-- Unfocused window visual studio logo color -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <Background Type="CT_RAW" Source="FF666666" />
+      </Color>
+      <Color Name="TextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextFillInverse">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="E4000000" />
+      </Color>
+      <Color Name="AccentFillDefault">
+        <!-- focused window color, and tab. EDITOR -->
+        <!-- ControlStrokeDefault -->
+        <Background Type="CT_RAW" Source="FFCA9EE6" />
+      </Color>
+      <Color Name="SubtleFillSecondary">
+        <!-- The hover color -->
+        <!-- Aparently this also controls the editor tab hover color -->
+        <!-- should be FF51576D -->
+        <!-- ToggleSelected -->
+        <Background Type="CT_RAW" Source="FF51576D" />
+      </Color>
+      <Color Name="CardStrokeDefaultSolidAlt">
+        <!-- The unfocused window color -->
+        <!-- CommandMouseOver -->
+        <Background Type="CT_RAW" Source="FF626880" />
+      </Color>
+      <Color Name="AccentTextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillSelectedText">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="80000000" />
+      </Color>
+      <Color Name="TextOnAccentFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="87FFFFFF" />
+      </Color>
+      <Color Name="ControlFillDefault">
+        <!-- Background of the comboboxes and explorer search bar -->
+        <!-- ComboBox -->
+        <Background Type="CT_RAW" Source="FF292C3C" />
+      </Color>
+      <Color Name="ControlFillSecondary">
+        <!-- Search bar from explorer, should be text box background?? (from the normal one) -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF414559" />
+      </Color>
+      <Color Name="ControlFillActiveInput">
+        <!-- Search bar background when focused -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF414559" />
+      </Color>
+      <Color Name="ControlStrokeDefault">
+        <!-- Combobox and Inputs Border color -->
+        <!-- Command -->
+        <Background Type="CT_RAW" Source="FFCA9EE6" />
+      </Color>
+      <Color Name="SolidBackgroundFillBase">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+      </Color>
+      <Color Name="SolidBackgroundFillSenary">
+        <!-- Inactive Tab color? Unfocused Tab color -->
+        <!-- MainWindowInactiveCaption -->
+        <Background Type="CT_RAW" Source="FF232634" />
+      </Color>
+      <Color Name="SolidBackgroundFillQuarternary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF2C2C2C" />
+      </Color>
+      <Color Name="SolidBackgroundFillTransparent">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="00202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillBaseAlt">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF0A0A0A" />
+      </Color>
+      <Color Name="SystemFillAttention">
+        <!-- Border active, decompiled or inspecting file (editor) -->
+        <!-- AccentFillDefault -->
+        <Background Type="CT_RAW" Source="FFCA9EE6" />
+      </Color>
+      <!-- end of new color -->
+	  <!-- start of renaming the sequel -->
+      <Color Name="SystemFillSuccess">
+        <Background Type="CT_RAW" Source="FF6CCB5F" />
+      </Color>
+      <Color Name="SystemFillCaution">
+        <Background Type="CT_RAW" Source="FFFCE100" />
+      </Color>
+      <Color Name="SystemFillCritical">
+        <Background Type="CT_RAW" Source="FFFF99A4" />
+      </Color>
+      <Color Name="SystemFillNeutral">
+        <Background Type="CT_RAW" Source="8BFFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidNeutral">
+        <Background Type="CT_RAW" Source="FF9D9D9D" />
+      </Color>
+      <Color Name="SystemFillAttentionBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSuccessBackground">
+        <Background Type="CT_RAW" Source="FF393D1B" />
+      </Color>
+      <Color Name="SystemFillCautionBackground">
+        <Background Type="CT_RAW" Source="FF433519" />
+      </Color>
+      <Color Name="SystemFillCriticalBackground">
+        <Background Type="CT_RAW" Source="FF442726" />
+      </Color>
+      <Color Name="SystemFillNeutralBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidAttentionBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <Color Name="SystemFillSolidNeutralBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <!-- end of renaming the sequel -->
       <Color Name="TextFillColorPrimary">
         <Background Type="CT_RAW" Source="FFFFFFFF" />
       </Color>
@@ -10362,6 +10547,79 @@
       </Color>
       <Color Name="SystemFillColorSolidNeutralBackground">
         <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+    </Category>
+    <!-- new env -->
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <!-- This is the background color -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF232634" />
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <!-- Actually, is the top bar bg color and inactive bg of the editor tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF232634" />
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <!-- Window border color -->
+        <!-- MainWindowActiveDefaultBorder -->
+        <Background Type="CT_RAW" Source="FF7160E8" />
+      </Color>
+      <Color Name="EnvironmentBorderInactive">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF414559" />
+      </Color>
+      <Color Name="EnvironmentLayeredBorder">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF414559" />
+      </Color>
+      <!-- THe experimental or preview badge color, InformationBadge  -->
+      <Color Name="EnvironmentBadge">
+        <!-- The badge of the PREVIEW or EXP thing -->
+        <!-- ButtonFace -->
+        <Background Type="CT_RAW" Source="FF51576D" />
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <!-- Focused window visual studio logo color -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <!-- MainWindowActiveIconDefault, MainWindowInactiveIconDefault -->
+        <Background Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <!-- StatusBarBuilding... -->
+      <Color Name="StatusBarControlFill">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillBuildingBackground">
+        <Background Type="CT_RAW" Source="FF232634" />
+        <Foreground Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillBuildingText">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingBackground">
+        <Background Type="CT_RAW" Source="FFEF9F76" />
+        <Foreground Type="CT_RAW" Source="FF232634" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingText">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionBackground">
+        <Background Type="CT_RAW" Source="FF232634" />
+        <Foreground Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionText">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillRestBackground">
+        <Background Type="CT_RAW" Source="FF232634" />
+        <Foreground Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarFillRestText">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
+      </Color>
+      <Color Name="StatusBarTextFillDisabled">
+        <Background Type="CT_RAW" Source="FFC6D0F5" />
       </Color>
     </Category>
     <Category Name="SQL Results - Grid" GUID="{6202ff3e-488e-4ead-92cb-be089659f8d7}">

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -6127,10 +6127,6 @@
         <Background Type="CT_RAW" Source="FF303446" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF414559" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5595,10 +5595,6 @@
         <Background Type="CT_RAW" Source="FFEFF1F5" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FFCCD0DA" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5591,8 +5591,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="OverviewMarginCollapsedRegion">

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -988,6 +988,37 @@
         <Background Type="CT_RAW" Source="FF939393" />
       </Color>
     </Category>
+    <Category Name="EditorOverride" GUID="{656339d7-0e39-43e2-98aa-becc3f87ffa5}">
+      <Color Name="PopupBackground">
+        <!-- <Color Name="Popup"> -->
+        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Foreground Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="PopupText">
+        <!-- ComboBoxText / Foreground -->
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="PopupBorder">
+        <!-- ToolTipBorder -->
+        <Background Type="CT_RAW" Source="FFACB0BE" />
+      </Color>
+      <Color Name="PopupSelectedBackground">
+        <!-- ListItemBackgroundSelected -->
+        <Background Type="CT_RAW" Source="FFBCC0CC" />
+      </Color>
+      <Color Name="PopupSelectedText">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+	  <Color Name="PopupLink">
+	  <!-- PanelHyperlinkInsideSelectionActive -->
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+	  </Color>
+	  <Color Name="PopupSubtleText">
+	  <!-- PanelHyperlinkInsideSelection -->
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+	  </Color>
+    </Category>
     <Category Name="Command Window" GUID="{ee1be240-4e81-4beb-8eea-54322b6b1bf5}">
       <Color Name="Plain Text">
         <Background Type="CT_RAW" Source="FF19171C" />
@@ -10212,6 +10243,160 @@
       </Color>
     </Category>
     <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="SolidBackgroundFillTertiary">
+        <!-- Explorer header and active tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+      </Color>
+      <!-- new color text (They renamed it) -->
+      <Color Name="TextFillPrimary">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="TextFillSecondary">
+        <!-- FileTabInactiveText -->
+        <!-- Example: An inactive tab -->
+        <Background Type="CT_RAW" Source="FF9CA0B0" />
+      </Color>
+      <Color Name="TextFillTertiary">
+        <!-- Unfocused window visual studio logo color -->
+        <!-- Active FF865FC5, Inactive 66000000 -->
+        <Background Type="CT_RAW" Source="66000000" />
+      </Color>
+      <Color Name="TextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5C000000" />
+      </Color>
+      <Color Name="TextFillInverse">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="AccentFillDefault">
+        <!-- focused window color, and tab. EDITOR -->
+        <!-- ControlStrokeDefault -->
+        <Background Type="CT_RAW" Source="FF8839EF" />
+      </Color>
+      <Color Name="SubtleFillSecondary">
+        <!-- The hover color -->
+        <!-- Aparently this also controls the editor tab hover color -->
+        <!-- should be FF45475A -->
+        <!-- ToggleSelected -->
+        <Background Type="CT_RAW" Source="FFBCC0CC" />
+      </Color>
+      <Color Name="CardStrokeDefaultSolidAlt">
+        <!-- The unfocused window color -->
+        <!-- CommandMouseOver -->
+        <Background Type="CT_RAW" Source="FFACB0BE" />
+      </Color>
+      <Color Name="AccentTextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5C000000" />
+      </Color>
+      <Color Name="TextOnAccentFillSelectedText">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="B3FFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="ControlFillDefault">
+        <!-- Background of the comboboxes and explorer search bar -->
+        <!-- ComboBox -->
+        <Background Type="CT_RAW" Source="FFE6E9EF" />
+      </Color>
+      <Color Name="ControlFillSecondary">
+        <!-- Search bar from explorer, should be text box background?? (from the normal one) -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
+      </Color>
+      <Color Name="ControlFillActiveInput">
+        <!-- Search bar background when focused -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
+      </Color>
+      <Color Name="ControlStrokeDefault">
+        <!-- Combobox and Inputs Border color -->
+        <!-- Command -->
+        <Background Type="CT_RAW" Source="FF8839EF" />
+      </Color>
+      <Color Name="SolidBackgroundFillBase">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFF3F3F3" />
+      </Color>
+      <Color Name="SolidBackgroundFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFEEEEEE" />
+      </Color>
+      <Color Name="SolidBackgroundFillSenary">
+        <!-- Inactive Tab color? Unfocused Tab color -->
+        <!-- MainWindowInactiveCaption -->
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+      </Color>
+      <Color Name="SolidBackgroundFillQuarternary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="SolidBackgroundFillTransparent">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="00F3F3F3" />
+      </Color>
+      <Color Name="SolidBackgroundFillBaseAlt">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFDADADA" />
+      </Color>
+      <Color Name="SystemFillAttention">
+        <!-- Border active, decompiled or inspecting file (editor) -->
+        <!-- AccentFillDefault -->
+        <Background Type="CT_RAW" Source="FF8839EF" />
+      </Color>
+      <!-- end of new color -->
+	  <!-- start of renaming the sequel -->
+      <Color Name="SystemFillSuccess">
+        <Background Type="CT_RAW" Source="FF0F7B0F" />
+      </Color>
+      <Color Name="SystemFillCaution">
+        <Background Type="CT_RAW" Source="FF9D5D00" />
+      </Color>
+      <Color Name="SystemFillCritical">
+        <Background Type="CT_RAW" Source="FFC42B1C" />
+      </Color>
+      <Color Name="SystemFillNeutral">
+        <Background Type="CT_RAW" Source="72000000" />
+      </Color>
+      <Color Name="SystemFillSolidNeutral">
+        <Background Type="CT_RAW" Source="FF8A8A8A" />
+      </Color>
+      <Color Name="SystemFillAttentionBackground">
+        <Background Type="CT_RAW" Source="80F6F6F6" />
+      </Color>
+      <Color Name="SystemFillSuccessBackground">
+        <Background Type="CT_RAW" Source="FFDFF6DD" />
+      </Color>
+      <Color Name="SystemFillCautionBackground">
+        <Background Type="CT_RAW" Source="FFFFF4CE" />
+      </Color>
+      <Color Name="SystemFillCriticalBackground">
+        <Background Type="CT_RAW" Source="FFFDE7E9" />
+      </Color>
+      <Color Name="SystemFillNeutralBackground">
+        <Background Type="CT_RAW" Source="06000000" />
+      </Color>
+      <Color Name="SystemFillSolidAttentionBackground">
+        <Background Type="CT_RAW" Source="FFF7F7F7" />
+      </Color>
+      <Color Name="SystemFillSolidNeutralBackground">
+        <Background Type="CT_RAW" Source="FFF3F3F3" />
+      </Color>
+      <!-- end of renaming the sequel -->
       <Color Name="TextFillColorPrimary">
         <Background Type="CT_RAW" Source="E4000000" />
       </Color>
@@ -10448,6 +10633,79 @@
       </Color>
       <Color Name="SystemFillColorSolidNeutralBackground">
         <Background Type="CT_RAW" Source="FFF3F3F3" />
+      </Color>
+    </Category>
+    <!-- new env -->
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <!-- This is the background color -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <!-- Actually, is the top bar bg color and inactive bg of the editor tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <!-- Window border color -->
+        <!-- MainWindowActiveDefaultBorder -->
+        <Background Type="CT_RAW" Source="FF9B9FB9" />
+      </Color>
+      <Color Name="EnvironmentBorderInactive">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
+      </Color>
+      <Color Name="EnvironmentLayeredBorder">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FFCCD0DA" />
+      </Color>
+      <!-- THe experimental or preview badge color, InformationBadge  -->
+      <Color Name="EnvironmentBadge">
+        <!-- The badge of the PREVIEW or EXP thing -->
+        <!-- ButtonFace -->
+        <Background Type="CT_RAW" Source="FFBCC0CC" />
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <!-- Focused window visual studio logo color -->
+        <!-- Active FF865FC5, Inactive 66000000 -->
+        <!-- MainWindowActiveIconDefault, MainWindowInactiveIconDefault -->
+        <Background Type="CT_RAW" Source="FF865FC5" />
+      </Color>
+      <!-- StatusBarBuilding... -->
+      <Color Name="StatusBarControlFill">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillBuildingBackground">
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+        <Foreground Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillBuildingText">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingBackground">
+        <Background Type="CT_RAW" Source="FFFE640B" />
+        <Foreground Type="CT_RAW" Source="FFDCE0E8" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingText">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionBackground">
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+        <Foreground Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionText">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillRestBackground">
+        <Background Type="CT_RAW" Source="FFDCE0E8" />
+        <Foreground Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarFillRestText">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
+      </Color>
+      <Color Name="StatusBarTextFillDisabled">
+        <Background Type="CT_RAW" Source="FF4C4F69" />
       </Color>
     </Category>
     <Category Name="ThemedAcceleratedDialog" GUID="{a2859846-e4aa-452d-ac41-8cc0e4e72e4c}">

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -6123,8 +6123,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF24273A" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF363A4F" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -6127,10 +6127,6 @@
         <Background Type="CT_RAW" Source="FF24273A" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF363A4F" />
         <Foreground Type="CT_INVALID" Source="00000000" />

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -988,6 +988,37 @@
         <Background Type="CT_RAW" Source="FFA2A4A5" />
       </Color>
     </Category>
+    <Category Name="EditorOverride" GUID="{656339d7-0e39-43e2-98aa-becc3f87ffa5}">
+      <Color Name="PopupBackground">
+        <!-- <Color Name="Popup"> -->
+        <Background Type="CT_RAW" Source="FF24273A" />
+        <Foreground Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="PopupText">
+        <!-- ComboBoxText / Foreground -->
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="PopupBorder">
+        <!-- ToolTipBorder -->
+        <Background Type="CT_RAW" Source="FF5B6078" />
+      </Color>
+      <Color Name="PopupSelectedBackground">
+        <!-- ListItemBackgroundSelected -->
+        <Background Type="CT_RAW" Source="FF494D64" />
+      </Color>
+      <Color Name="PopupSelectedText">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+	  <Color Name="PopupLink">
+	  <!-- PanelHyperlinkInsideSelectionActive -->
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+	  </Color>
+	  <Color Name="PopupSubtleText">
+	  <!-- PanelHyperlinkInsideSelection -->
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+	  </Color>
+    </Category>
     <Category Name="Command Window" GUID="{ee1be240-4e81-4beb-8eea-54322b6b1bf5}">
       <Color Name="Plain Text">
         <Background Type="CT_RAW" Source="FF19171C" />
@@ -10062,6 +10093,160 @@
       </Color>
     </Category>
     <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="SolidBackgroundFillTertiary">
+        <!-- Explorer header and active tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF181926" />
+      </Color>
+      <!-- new color text (they renamed it) -->
+      <Color Name="TextFillPrimary">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="TextFillSecondary">
+        <!-- FileTabInactiveText -->
+        <!-- Example: An inactive tab -->
+        <Background Type="CT_RAW" Source="FF6C7086" />
+      </Color>
+      <Color Name="TextFillTertiary">
+        <!-- Unfocused window visual studio logo color -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <Background Type="CT_RAW" Source="FF666666" />
+      </Color>
+      <Color Name="TextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextFillInverse">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="E4000000" />
+      </Color>
+      <Color Name="AccentFillDefault">
+        <!-- focused window color, and tab. EDITOR -->
+        <!-- ControlStrokeDefault -->
+        <Background Type="CT_RAW" Source="FFC6A0F6" />
+      </Color>
+      <Color Name="SubtleFillSecondary">
+        <!-- The hover color -->
+        <!-- Aparently this also controls the editor tab hover color -->
+        <!-- should be FF494D64 -->
+        <!-- ToggleSelected -->
+        <Background Type="CT_RAW" Source="FF494D64" />
+      </Color>
+      <Color Name="CardStrokeDefaultSolidAlt">
+        <!-- The unfocused window color -->
+        <!-- CommandMouseOver -->
+        <Background Type="CT_RAW" Source="FF5B6078" />
+      </Color>
+      <Color Name="AccentTextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillSelectedText">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="80000000" />
+      </Color>
+      <Color Name="TextOnAccentFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="87FFFFFF" />
+      </Color>
+      <Color Name="ControlFillDefault">
+        <!-- Background of the comboboxes and explorer search bar -->
+        <!-- ComboBox -->
+        <Background Type="CT_RAW" Source="FF1E2030" />
+      </Color>
+      <Color Name="ControlFillSecondary">
+        <!-- Search bar from explorer, should be text box background?? (from the normal one) -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF363A4F" />
+      </Color>
+      <Color Name="ControlFillActiveInput">
+        <!-- Search bar background when focused -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF363A4F" />
+      </Color>
+      <Color Name="ControlStrokeDefault">
+        <!-- Combobox and Inputs Border color -->
+        <!-- Command -->
+        <Background Type="CT_RAW" Source="FFC6A0F6" />
+      </Color>
+      <Color Name="SolidBackgroundFillBase">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+      </Color>
+      <Color Name="SolidBackgroundFillSenary">
+        <!-- Inactive Tab color? Unfocused Tab color -->
+        <!-- MainWindowInactiveCaption -->
+        <Background Type="CT_RAW" Source="FF181926" />
+      </Color>
+      <Color Name="SolidBackgroundFillQuarternary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF2C2C2C" />
+      </Color>
+      <Color Name="SolidBackgroundFillTransparent">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="00202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillBaseAlt">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF0A0A0A" />
+      </Color>
+      <Color Name="SystemFillAttention">
+        <!-- Border active, decompiled or inspecting file (editor) -->
+        <!-- AccentFillDefault -->
+        <Background Type="CT_RAW" Source="FFC6A0F6" />
+      </Color>
+      <!-- end of new color -->
+	  <!-- start of renaming the sequel -->
+      <Color Name="SystemFillColorSuccess">
+        <Background Type="CT_RAW" Source="FF6CCB5F" />
+      </Color>
+      <Color Name="SystemFillCaution">
+        <Background Type="CT_RAW" Source="FFFCE100" />
+      </Color>
+      <Color Name="SystemFillCritical">
+        <Background Type="CT_RAW" Source="FFFF99A4" />
+      </Color>
+      <Color Name="SystemFillNeutral">
+        <Background Type="CT_RAW" Source="8BFFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidNeutral">
+        <Background Type="CT_RAW" Source="FF9D9D9D" />
+      </Color>
+      <Color Name="SystemFillAttentionBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSuccessBackground">
+        <Background Type="CT_RAW" Source="FF393D1B" />
+      </Color>
+      <Color Name="SystemFillCautionBackground">
+        <Background Type="CT_RAW" Source="FF433519" />
+      </Color>
+      <Color Name="SystemFillCriticalBackground">
+        <Background Type="CT_RAW" Source="FF442726" />
+      </Color>
+      <Color Name="SystemFillNeutralBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidAttentionBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <Color Name="SystemFillSolidNeutralBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <!-- end of renaming the sequel -->
       <Color Name="TextFillColorPrimary">
         <Background Type="CT_RAW" Source="FFFFFFFF" />
       </Color>
@@ -10298,6 +10483,79 @@
       </Color>
       <Color Name="SystemFillColorSolidNeutralBackground">
         <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+    </Category>
+    <!-- new env bg -->
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <!-- This is the background color -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF181926" />
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <!-- Actually, is the top bar bg color and inactive bg of the editor tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF181926" />
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <!-- Window border color -->
+        <!-- MainWindowActiveDefaultBorder -->
+        <Background Type="CT_RAW" Source="FF7160E8" />
+      </Color>
+      <Color Name="EnvironmentBorderInactive">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF363A4F" />
+      </Color>
+      <Color Name="EnvironmentLayeredBorder">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF363A4F" />
+      </Color>
+      <!-- THe experimental or preview badge color, InformationBadge  -->
+      <Color Name="EnvironmentBadge">
+        <!-- The badge of the PREVIEW or EXP thing -->
+        <!-- ButtonFace -->
+        <Background Type="CT_RAW" Source="FF494D64" />
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <!-- Active color of the vs logo -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <!-- MainWindowActiveIconDefault, MainWindowInactiveIconDefault -->
+        <Background Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <!-- StatusBarBuilding... -->
+      <Color Name="StatusBarControlFill">
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillBuildingBackground">
+        <Background Type="CT_RAW" Source="FF181926" />
+        <Foreground Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillBuildingText">
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingBackground">
+        <Background Type="CT_RAW" Source="FFF5A97F" />
+        <Foreground Type="CT_RAW" Source="FF181926" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingText">
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionBackground">
+        <Background Type="CT_RAW" Source="FF181926" />
+        <Foreground Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionText">
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillRestBackground">
+        <Background Type="CT_RAW" Source="FF181926" />
+        <Foreground Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarFillRestText">
+        <Background Type="CT_RAW" Source="FFCAD3F5" />
+      </Color>
+      <Color Name="StatusBarTextFillDisabled">
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
       </Color>
     </Category>
     <Category Name="SQL Results - Grid" GUID="{6202ff3e-488e-4ead-92cb-be089659f8d7}">

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -6072,8 +6072,16 @@
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
+      <Color Name="StickyScroll Background">
+        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Foreground Type="CT_INVALID" Source="00000000" />
+      </Color>
+      <!--
+      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
+      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
+      -->
       <Color Name="StickyScrollLineHighlightFormat">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF313244" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="BraceCompletionClosingBrace">

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -988,6 +988,37 @@
         <Background Type="CT_RAW" Source="FFA2A4A5" />
       </Color>
     </Category>
+    <Category Name="EditorOverride" GUID="{656339d7-0e39-43e2-98aa-becc3f87ffa5}">
+      <Color Name="PopupBackground">
+        <!-- <Color Name="Popup"> -->
+        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Foreground Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="PopupText">
+        <!-- ComboBoxText / Foreground -->
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="PopupBorder">
+        <!-- ToolTipBorder -->
+        <Background Type="CT_RAW" Source="FF585B70" />
+      </Color>
+      <Color Name="PopupSelectedBackground">
+        <!-- ListItemBackgroundSelected -->
+        <Background Type="CT_RAW" Source="FF45475A" />
+      </Color>
+      <Color Name="PopupSelectedText">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+	  <Color Name="PopupLink">
+	  <!-- PanelHyperlinkInsideSelectionActive -->
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+	  </Color>
+	  <Color Name="PopupSubtleText">
+	  <!-- PanelHyperlinkInsideSelection -->
+	    <Background Type="CT_RAW" Source="FFCDD6F4" />
+	  </Color>
+    </Category>
     <Category Name="Command Window" GUID="{ee1be240-4e81-4beb-8eea-54322b6b1bf5}">
       <Color Name="Plain Text">
         <Background Type="CT_RAW" Source="FF19171C" />
@@ -10275,6 +10306,160 @@
       </Color>
     </Category>
     <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="SolidBackgroundFillTertiary">
+        <!-- Explorer header and active tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <!-- new color text (They renamed it) -->
+      <Color Name="TextFillPrimary">
+        <!-- WindowText -->
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="TextFillSecondary">
+        <!-- FileTabInactiveText -->
+        <!-- Example: An inactive tab -->
+        <Background Type="CT_RAW" Source="FF6C7086" />
+      </Color>
+      <Color Name="TextFillTertiary">
+        <!-- Unfocused window visual studio logo color -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <Background Type="CT_RAW" Source="FF666666" />
+      </Color>
+      <Color Name="TextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextFillInverse">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="E4000000" />
+      </Color>
+      <Color Name="AccentFillDefault">
+        <!-- focused window color, and tab. EDITOR -->
+        <!-- ControlStrokeDefault -->
+        <Background Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <Color Name="SubtleFillSecondary">
+        <!-- The hover color -->
+        <!-- Aparently this also controls the editor tab hover color -->
+        <!-- should be FF45475A -->
+        <!-- ToggleSelected -->
+        <Background Type="CT_RAW" Source="FF45475A" />
+      </Color>
+      <Color Name="CardStrokeDefaultSolidAlt">
+        <!-- The unfocused window color -->
+        <!-- CommandMouseOver -->
+        <Background Type="CT_RAW" Source="FF585B70" />
+      </Color>
+      <Color Name="AccentTextFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="5DFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillSelectedText">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FFFFFFFF" />
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="80000000" />
+      </Color>
+      <Color Name="TextOnAccentFillDisabled">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="87FFFFFF" />
+      </Color>
+      <Color Name="ControlFillDefault">
+        <!-- Background of the comboboxes and explorer search bar -->
+        <!-- ComboBox -->
+        <Background Type="CT_RAW" Source="FF181825" />
+      </Color>
+      <Color Name="ControlFillSecondary">
+        <!-- Search bar from explorer, should be text box background?? (from the normal one) -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF313244" />
+      </Color>
+      <Color Name="ControlFillActiveInput">
+        <!-- Search bar background when focused -->
+        <!-- Input -->
+        <Background Type="CT_RAW" Source="FF313244" />
+      </Color>
+      <Color Name="ControlStrokeDefault">
+        <!-- Combobox and Inputs Border color -->
+        <!-- Command -->
+        <Background Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <Color Name="SolidBackgroundFillBase">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillSecondary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF1C1C1C" />
+      </Color>
+      <Color Name="SolidBackgroundFillSenary">
+        <!-- Inactive Tab color? Unfocused Tab color -->
+        <!-- MainWindowInactiveCaption -->
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="SolidBackgroundFillQuarternary">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF2C2C2C" />
+      </Color>
+      <Color Name="SolidBackgroundFillTransparent">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="00202020" />
+      </Color>
+      <Color Name="SolidBackgroundFillBaseAlt">
+        <!-- unmodified -->
+        <Background Type="CT_RAW" Source="FF0A0A0A" />
+      </Color>
+      <Color Name="SystemFillAttention">
+        <!-- Border active, decompiled or inspecting file (editor) -->
+        <!-- AccentFillDefault -->
+        <Background Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <!-- end of new color -->
+      <!-- start of renaming the sequel -->
+      <Color Name="SystemFillSuccess">
+        <Background Type="CT_RAW" Source="FF6CCB5F" />
+      </Color>
+      <Color Name="SystemFillCaution">
+        <Background Type="CT_RAW" Source="FFFCE100" />
+      </Color>
+      <Color Name="SystemFillCritical">
+        <Background Type="CT_RAW" Source="FFFF99A4" />
+      </Color>
+      <Color Name="SystemFillNeutral">
+        <Background Type="CT_RAW" Source="8BFFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidNeutral">
+        <Background Type="CT_RAW" Source="FF9D9D9D" />
+      </Color>
+      <Color Name="SystemFillAttentionBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSuccessBackground">
+        <Background Type="CT_RAW" Source="FF393D1B" />
+      </Color>
+      <Color Name="SystemFillCautionBackground">
+        <Background Type="CT_RAW" Source="FF433519" />
+      </Color>
+      <Color Name="SystemFillCriticalBackground">
+        <Background Type="CT_RAW" Source="FF442726" />
+      </Color>
+      <Color Name="SystemFillNeutralBackground">
+        <Background Type="CT_RAW" Source="08FFFFFF" />
+      </Color>
+      <Color Name="SystemFillSolidAttentionBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <Color Name="SystemFillSolidNeutralBackground">
+        <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+      <!-- end of renaming the sequel -->
       <Color Name="TextFillColorPrimary">
         <Background Type="CT_RAW" Source="FFFFFFFF" />
       </Color>
@@ -10511,6 +10696,79 @@
       </Color>
       <Color Name="SystemFillColorSolidNeutralBackground">
         <Background Type="CT_RAW" Source="FF2E2E2E" />
+      </Color>
+    </Category>
+    <!-- new env -->
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <!-- This is the background color -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <!-- Actually, is the top bar bg color and inactive bg of the editor tabs -->
+        <!-- EnvironmentBackground -->
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <!-- Window border color -->
+        <!-- MainWindowActiveDefaultBorder -->
+        <Background Type="CT_RAW" Source="FF7160E8" />
+      </Color>
+      <Color Name="EnvironmentBorderInactive">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF313244" />
+      </Color>
+      <Color Name="EnvironmentLayeredBorder">
+        <!-- ControlFillSecondary -->
+        <Background Type="CT_RAW" Source="FF313244" />
+      </Color>
+      <!-- THe experimental or preview badge color, InformationBadge  -->
+      <Color Name="EnvironmentBadge">
+        <!-- The badge of the PREVIEW or EXP thing -->
+        <!-- ButtonFace -->
+        <Background Type="CT_RAW" Source="FF45475A" />
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <!-- Focused window visual studio logo color -->
+        <!-- Active FFD6D6D6, Inactive FF666666 -->
+        <!-- MainWindowActiveIconDefault, MainWindowInactiveIconDefault -->
+        <Background Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <!-- StatusBarBuilding... -->
+      <Color Name="StatusBarControlFill">
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="StatusBarFillBuildingBackground">
+        <Background Type="CT_RAW" Source="FF11111B" />
+        <Foreground Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarFillBuildingText">
+        <Background Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingBackground">
+        <Background Type="CT_RAW" Source="FFFAB387" />
+        <Foreground Type="CT_RAW" Source="FF11111B" />
+      </Color>
+      <Color Name="StatusBarFillDebuggingText">
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionBackground">
+        <Background Type="CT_RAW" Source="FF11111B" />
+        <Foreground Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarFillNoSolutionText">
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarFillRestBackground">
+        <Background Type="CT_RAW" Source="FF11111B" />
+        <Foreground Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarFillRestText">
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
+      </Color>
+      <Color Name="StatusBarTextFillDisabled">
+        <Background Type="CT_RAW" Source="FFCDD6F4" />
       </Color>
     </Category>
     <Category Name="SQL Results - Grid" GUID="{6202ff3e-488e-4ead-92cb-be089659f8d7}">

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -6076,10 +6076,6 @@
         <Background Type="CT_RAW" Source="FF1E1E2E" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
-      <!--
-      I don't know how to adjust the hardcoded (?) 0.25 opacity to the overlay rectangle.
-      A possible workaround is adjusting the color to compensate for the opacity, but then the border color will be affected.
-      -->
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_RAW" Source="FF313244" />
         <Foreground Type="CT_INVALID" Source="00000000" />


### PR DESCRIPTION
Alright, so this time I actually added the support for the Refresh UI... but, there are still some little quirks.

I picked colors for things that didn’t have them in the old version or didn't work with the new version, like:
- Inactive and active window borders (EnvironmentBorderInactive)
- Top bar border
- Project badge and VS version (they both use the same color identifier)
- Active editor window border

Now, for the minor annoyances:
- The hover color is shared across editor tabs, file headers, and buttons
- The text color (surprise!) is used for both the text and icons (tabs).
- And probably some other stuff that I haven’t discovered yet

_shower:_
<details>
<summary>Latte</summary>
<img src="https://github.com/user-attachments/assets/6634d65e-2ca3-463d-953a-2e8d33a0e1ac" />
</details>

<details>
<summary>Mocha</summary>
<img src="https://github.com/user-attachments/assets/9107329e-0ff3-4856-b610-d36c4ad26f31" />
</details>

<details>
<summary>Macchiato</summary>
<img src="https://github.com/user-attachments/assets/7d441ece-525f-450e-bd31-2a6b22a7d556" />
</details>

<details>
<summary>Frappé</summary>
<img src="https://github.com/user-attachments/assets/936d44e4-fe3f-4c9b-be8f-d6f2bd450eb4" />
</details>

Also, heads up! This is a little bit janky because of the vstheme being trashed with comments. I can clean that up when finally merging, after it's checked that it works correctly.

This should really fix issue #50.

_btw, forgot about updating my fork before pushing... ha ha_




