### PR TITLE
 #60 Display issue with Visual Studio 2022 17.12

### DIFF
--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -5159,6 +5159,14 @@
       </Color>
     </Category>
     <Category Name="Azure Resource Manager Tools" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="outlining.chevron.expanded">
+        <Background Type="CT_RAW" Source="FF303446" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <Color Name="outlining.chevron.collapsed">
+        <Background Type="CT_RAW" Source="FF303446" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
       <Color Name="Rainbow Brace level 1">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FFCBA6F7" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5159,6 +5159,15 @@
       </Color>
     </Category>
     <Category Name="Cpp Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="outlining.chevron.expanded">
+        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Foreground Type="CT_RAW" Source="FF8839ef" />
+      </Color>
+      <Color Name="outlining.chevron.collapsed">
+        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Foreground Type="CT_RAW" Source="FF8839ef" />
+      </Color>
+      
       <Color Name="Rainbow Brace level 1">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FF8839ef" />

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -5159,6 +5159,14 @@
       </Color>
     </Category>
     <Category Name="Cpp Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="outlining.chevron.expanded">
+        <Background Type="CT_RAW" Source="FF24273A" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <Color Name="outlining.chevron.collapsed">
+        <Background Type="CT_RAW" Source="FF24273A" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>      
       <Color Name="Rainbow Brace level 1">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FFCBA6F7" />

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -5160,6 +5160,14 @@
       </Color>
     </Category>
     <Category Name="Azure Resource Manager Tools" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="outlining.chevron.expanded">
+        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>
+      <Color Name="outlining.chevron.collapsed">
+        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Foreground Type="CT_RAW" Source="FFCBA6F7" />
+      </Color>      
       <Color Name="property name">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FF89B4FA" />


### PR DESCRIPTION
PR adds configuration for the `outlining.chevron` element added in Visual Studio 2022 17.12
<img width="146" alt="frappe" src="https://github.com/user-attachments/assets/f95c53fa-9d4f-4105-abe9-195b2125d757">
<img width="114" alt="latte" src="https://github.com/user-attachments/assets/14828ef3-0bff-4035-9173-fa9ec5a56c4a">
<img width="131" alt="mcc" src="https://github.com/user-attachments/assets/a5913d9c-2066-4792-a06b-a9f63b1988de">
<img width="119" alt="mocha" src="https://github.com/user-attachments/assets/578b44fa-e1e1-4024-8920-21684d792f2d">
