### PR TITLE
Make breakpoint gutter visible

### DIFF
--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -8801,7 +8801,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Indicator Margin">
-        <Background Type="CT_RAW" Source="FF303446" />
+        <Background Type="CT_RAW" Source="FF414559" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
     </Category>

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -5167,7 +5167,7 @@
         <Background Type="CT_RAW" Source="FFEFF1F5" />
         <Foreground Type="CT_RAW" Source="FF8839ef" />
       </Color>
-      
+
       <Color Name="Rainbow Brace level 1">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FF8839ef" />
@@ -8738,7 +8738,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Indicator Margin">
-        <Background Type="CT_RAW" Source="FFEFF1F5" />
+        <Background Type="CT_RAW" Source="FFE6E9EF" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
     </Category>

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -5166,7 +5166,7 @@
       <Color Name="outlining.chevron.collapsed">
         <Background Type="CT_RAW" Source="FF24273A" />
         <Foreground Type="CT_RAW" Source="FFCBA6F7" />
-      </Color>      
+      </Color>
       <Color Name="Rainbow Brace level 1">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FFCBA6F7" />
@@ -8737,7 +8737,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Indicator Margin">
-        <Background Type="CT_RAW" Source="FF24273A" />
+        <Background Type="CT_RAW" Source="FF363A4F" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
     </Category>

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -5167,7 +5167,7 @@
       <Color Name="outlining.chevron.collapsed">
         <Background Type="CT_RAW" Source="FF1E1E2E" />
         <Foreground Type="CT_RAW" Source="FFCBA6F7" />
-      </Color>      
+      </Color>
       <Color Name="property name">
         <Background Type="CT_INVALID" Source="00000000" />
         <Foreground Type="CT_RAW" Source="FF89B4FA" />
@@ -8950,7 +8950,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Indicator Margin">
-        <Background Type="CT_RAW" Source="FF1E1E2E" />
+        <Background Type="CT_RAW" Source="FF313244" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
     </Category>


### PR DESCRIPTION
Currently, the breakpoint gutter ("Indicator Margin") is the same color as the editor background, which makes it difficult to click and add breakpoints.

I made the gutter one palette shade lighter (or darker in the case of Latte) according to the palette defined in `//.dev/ThemeConvert.ps1`.

| Theme | Before | After |
|--------|--------|--------|
| Latte | Cell | ![image](https://github.com/user-attachments/assets/52249d0c-aef8-4942-8750-6fd254552afa) |
| Frappe | Cell | ![image](https://github.com/user-attachments/assets/01d6d76e-71b1-42c1-8df2-b2531c925975) |
| Macchiato | Cell | ![image](https://github.com/user-attachments/assets/3088b19b-b7b2-4c72-b8be-21a15503067e) |
| Mocha | Cell | ![image](https://github.com/user-attachments/assets/1fe96cd5-d2ba-438d-b1bd-f7f489b61aa1) |