### PR TITLE
fix: Remove spaces from .vsix package name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,5 +19,5 @@ jobs:
         run: msbuild /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal 'Catppuccin VS Themes'
       - uses: actions/upload-artifact@v4
         with:
-          name: Catppuccin for Visual Studio.vsix
-          path: Catppuccin VS Themes\bin\Release\Catppuccin for Visual Studio.vsix
+          name: Catppuccin.for.Visual.Studio.vsix
+          path: Catppuccin VS Themes\bin\Release\Catppuccin.for.Visual.Studio.vsix

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,10 +36,10 @@ jobs:
       - name: Upload Artifact to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} "Catppuccin VS Themes\bin\Release\Catppuccin for Visual Studio.vsix"
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} "Catppuccin VS Themes\bin\Release\Catppuccin.for.Visual.Studio.vsix"
       - name: Publish to Visual Studio Marketplace
         uses: cezarypiatek/VsixPublisherAction@1.1
         with:
-          extension-file: '"Catppuccin VS Themes/bin/Release/Catppuccin for Visual Studio.vsix"'
+          extension-file: '"Catppuccin VS Themes/bin/Release/Catppuccin.for.Visual.Studio.vsix"'
           publish-manifest-file: '"Catppuccin VS Themes/marketplace.json"'
           personal-access-code: ${{ secrets.VS_MARKETPLACE_TOKEN }}

--- a/Catppuccin VS Themes/Catppuccin for Visual Studio.csproj
+++ b/Catppuccin VS Themes/Catppuccin for Visual Studio.csproj
@@ -15,6 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Catppuccin</RootNamespace>
     <AssemblyName>Catppuccin for Visual Studio</AssemblyName>
+    <TargetVsixContainerName>Catppuccin.for.Visual.Studio.vsix</TargetVsixContainerName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>


### PR DESCRIPTION
The default .vsix package name contains spaces, which are invalid according to the publishing tool:

> VSSDK: error VsixPub0036 : The file name of the payload (Catppuccin
> for Visual Studio.vsix) contains some invalid characters.

This wasn't a problem when uploaded manually as the UI would auto-adjust the name. This change fixes that by replacing the spaces with periods to match the upload UI behavior.