### PR TITLE
Add tokens for Visual Studio 2026 support

### DIFF
--- a/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/.gitignore
+++ b/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.Catppuccin for Visual Studio.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/.name
+++ b/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/.name
@@ -1,0 +1,1 @@
+Catppuccin for Visual Studio

--- a/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/encodings.xml
+++ b/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/indexLayout.xml
+++ b/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/vcs.xml
+++ b/Catppuccin VS Themes/.idea/.idea.Catppuccin for Visual Studio/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -10969,6 +10969,9 @@
       <Color Name="TextOnAccentFillSecondary">
         <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
       </Color>
+      <Color Name="ControlFillDefault">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
     </Category>
 
     <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
@@ -10985,6 +10988,9 @@
         <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
       </Color>
       <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+      <Color Name="StatusBarBackgroundFillSolutionLoading">
         <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
       </Color>
     </Category>

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -2096,7 +2096,7 @@
         <Background Type="CT_RAW" Source="FF292C3C" />
       </Color>
       <Color Name="ComboBoxPopupBackgroundEnd">
-        <Background Type="CT_RAW" Source="FF292C3C" />
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
       </Color>
       <Color Name="DropDownBackground">
         <Background Type="CT_RAW" Source="FF292C3C" />
@@ -2620,7 +2620,7 @@
         <Background Type="CT_RAW" Source="66414559" />
       </Color>
       <Color Name="ScrollBarThumbPressedBackground">
-        <Background Type="CT_RAW" Source="66414559" />
+        <Background Type="CT_RAW" Source="FFC6D0F5" /> <!-- Text -->
       </Color>
       <Color Name="AutoHideResizeGrip">
         <Background Type="CT_RAW" Source="FF484D62" />
@@ -3756,7 +3756,7 @@
         <Background Type="CT_RAW" Source="FF3D3D3D" />
       </Color>
       <Color Name="PageSideBarExpanderSeparator">
-        <Background Type="CT_RAW" Source="FF3D3D3D" />
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Lavender -->
       </Color>
       <Color Name="PageSideBarExpanderText">
         <Background Type="CT_RAW" Source="FFFAFAFA" />

--- a/Catppuccin VS Themes/Catppuccin Frappé.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Frappé.vstheme
@@ -1,5 +1,5 @@
 <Themes>
-  <Theme Name="Catppuccin Frappé" GUID="{217075d3-6c1c-432d-9587-ca060f7229fe}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
+  <Theme Name="Catppuccin Frappé" GUID="{217075d3-6c1c-432d-9587-ca060f7229fe}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
     <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
       <Color Name="NumberedListItemActive">
         <Background Type="CT_RAW" Source="FF303446" />
@@ -10936,5 +10936,58 @@
         <Foreground Type="CT_RAW" Source="FF404040" />
       </Color>
     </Category>
+
+    <!-- Visual Studio 2026 -->
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="AccentFillDefault">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color>
+      <Color Name="AccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF7F8BCF" /> <!-- Lavender (Slightly Darkened) -->
+      </Color>
+      <Color Name="AccentFillTertiary">
+        <Background Type="CT_RAW" Source="CC9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="SolidBackgroundFillTertiary">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+      <Color Name="SolidBackgroundFillQuaternary">
+        <Background Type="CT_RAW" Source="FF303446" /> <!-- Base -->
+      </Color>
+      <Color Name="SurfaceBackgroundFillDefault">
+        <Background Type="CT_RAW" Source="FF232634" /> <!-- Crust -->
+      </Color>
+      <Color Name="TextFillSecondary">
+        <Background Type="CT_RAW" Source="FFBABBF1" /> <!-- Lavender -->
+      </Color>
+      <Color Name="TextFillPrimary">
+        <Background Type="CT_RAW" Source="FFC6D0F5" /> <!-- Text -->
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+    </Category>
+
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <Background Type="CT_RAW" Source="FFCA9EE6" /> <!-- Mauve -->
+      </Color>
+      <Color Name="EnvironmentIndicator">
+        <Background Type="CT_RAW" Source="66757575" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF292C3C" /> <!-- Mantle -->
+      </Color>
+    </Category>
+    
   </Theme>
 </Themes>

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -12773,6 +12773,9 @@
       <Color Name="TextOnAccentFillSecondary">
         <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
       </Color>
+      <Color Name="ControlFillDefault">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
     </Category>
 
     <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
@@ -12789,6 +12792,9 @@
         <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
       </Color>
       <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+      <Color Name="StatusBarBackgroundFillSolutionLoading">
         <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
       </Color>
     </Category>    

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -2096,7 +2096,7 @@
         <Background Type="CT_RAW" Source="FFE6E9EF" />
       </Color>
       <Color Name="ComboBoxPopupBackgroundEnd">
-        <Background Type="CT_RAW" Source="FFE6E9EF" />
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
       </Color>
       <Color Name="DropDownBackground">
         <Background Type="CT_RAW" Source="FFE6E9EF" />
@@ -2620,7 +2620,7 @@
         <Background Type="CT_RAW" Source="66CCD0DA" />
       </Color>
       <Color Name="ScrollBarThumbPressedBackground">
-        <Background Type="CT_RAW" Source="66CCD0DA" />
+        <Background Type="CT_RAW" Source="FF4C4F69" /> <!-- Lavender -->
       </Color>
       <Color Name="AutoHideResizeGrip">
         <Background Type="CT_RAW" Source="FFCDD0D9" />
@@ -3756,7 +3756,7 @@
         <Background Type="CT_RAW" Source="FFFEFEFE" />
       </Color>
       <Color Name="PageSideBarExpanderSeparator">
-        <Background Type="CT_RAW" Source="FFCCCEDB" />
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
       </Color>
       <Color Name="PageSideBarExpanderText">
         <Background Type="CT_RAW" Source="FF1E1E1E" />

--- a/Catppuccin VS Themes/Catppuccin Latte.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Latte.vstheme
@@ -12740,5 +12740,57 @@
         <Background Type="CT_RAW" Source="7FE6E9EF" />
       </Color>
     </Category>
+
+    <!-- Visual Studio 2026 -->
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="AccentFillDefault">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color> 
+      <Color Name="AccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF7F8BCF" /> <!-- Lavender (Slightly Darkened) -->
+      </Color>
+      <Color Name="AccentFillTertiary">
+        <Background Type="CT_RAW" Source="CC9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="SolidBackgroundFillTertiary">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+      <Color Name="SolidBackgroundFillQuaternary">
+        <Background Type="CT_RAW" Source="FFEFF1F5" /> <!-- Base -->
+      </Color>
+      <Color Name="SurfaceBackgroundFillDefault">
+        <Background Type="CT_RAW" Source="FFDCE0E8" /> <!-- Crust -->
+      </Color>
+      <Color Name="TextFillSecondary">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color>
+      <Color Name="TextFillPrimary">
+        <Background Type="CT_RAW" Source="FF4C4F69" /> <!-- Text -->
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+    </Category>
+
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color>
+      <Color Name="EnvironmentIndicator">
+        <Background Type="CT_RAW" Source="66757575" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FFE6E9EF" /> <!-- Mantle -->
+      </Color>
+    </Category>    
   </Theme>
 </Themes>

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -12772,8 +12772,11 @@
       <Color Name="TextOnAccentFillSecondary">
         <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
       </Color>
+      <Color Name="ControlFillDefault">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
     </Category>
-    
+        
     <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
       <Color Name="EnvironmentBackground">
         <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
@@ -12788,6 +12791,9 @@
         <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
       </Color>
       <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+      <Color Name="StatusBarBackgroundFillSolutionLoading">
         <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
       </Color>
     </Category>

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -2096,7 +2096,7 @@
         <Background Type="CT_RAW" Source="FF1E2030" />
       </Color>
       <Color Name="ComboBoxPopupBackgroundEnd">
-        <Background Type="CT_RAW" Source="FF1E2030" />
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
       </Color>
       <Color Name="DropDownBackground">
         <Background Type="CT_RAW" Source="FF1E2030" />
@@ -2620,7 +2620,7 @@
         <Background Type="CT_RAW" Source="66363A4F" />
       </Color>
       <Color Name="ScrollBarThumbPressedBackground">
-        <Background Type="CT_RAW" Source="66363A4F" />
+        <Background Type="CT_RAW" Source="FFCAD3f5" /> <!-- Lavender -->
       </Color>
       <Color Name="AutoHideResizeGrip">
         <Background Type="CT_RAW" Source="FF3F4358" />
@@ -3756,7 +3756,7 @@
         <Background Type="CT_RAW" Source="FF3D3D3D" />
       </Color>
       <Color Name="PageSideBarExpanderSeparator">
-        <Background Type="CT_RAW" Source="FF3D3D3D" />
+        <Background Type="CT_RAW" Source="FFB7BDf8" /> <!-- Lavender -->
       </Color>
       <Color Name="PageSideBarExpanderText">
         <Background Type="CT_RAW" Source="FFFAFAFA" />

--- a/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Macchiato.vstheme
@@ -1,5 +1,5 @@
 <Themes>
-  <Theme Name="Catppuccin Macchiato" GUID="{52937d60-147a-40f6-9dba-8b4ae9b5eeea}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
+  <Theme Name="Catppuccin Macchiato" GUID="{52937d60-147a-40f6-9dba-8b4ae9b5eeea}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
     <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
       <Color Name="NumberedListItemActive">
         <Background Type="CT_RAW" Source="FF24273A" />
@@ -12739,5 +12739,61 @@
         <Background Type="CT_RAW" Source="7F1E2030" />
       </Color>
     </Category>
+
+    <!-- Visual Studio 2026 -->   
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="AccentFillDefault">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color>
+      <Color Name="AccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF7F8BCF" /> <!-- Lavender (Slightly Darkened) -->
+      </Color>
+      <Color Name="AccentFillTertiary">
+        <Background Type="CT_RAW" Source="CC9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="SolidBackgroundFillTertiary">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+      <Color Name="SolidBackgroundFillQuaternary">
+        <Background Type="CT_RAW" Source="FF24273A" /> <!-- Base -->
+      </Color>
+      <Color Name="SurfaceBackgroundFillDefault">
+        <Background Type="CT_RAW" Source="FF181926" /> <!-- Crust -->
+      </Color>
+      <Color Name="TextFillSecondary">
+        <Background Type="CT_RAW" Source="FFB7BDf8" /> <!-- Lavender -->
+      </Color>
+      <Color Name="TextFillPrimary">
+        <Background Type="CT_RAW" Source="FFCAD3f5" /> <!-- Text -->
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+    </Category>
+    
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <Background Type="CT_RAW" Source="FFC6A0F6" /> <!-- Mauve -->
+      </Color>
+      <Color Name="EnvironmentIndicator">
+        <Background Type="CT_RAW" Source="66757575" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF1E2030" /> <!-- Mantle -->
+      </Color>
+    </Category>
+
   </Theme>
 </Themes>
+
+
+

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -1,5 +1,5 @@
 <Themes>
-  <Theme Name="Catppuccin Mocha" GUID="{17212aeb-75b2-4b6b-beb2-44d212caa2a9}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
+  <Theme Name="Catppuccin Mocha" GUID="{17212aeb-75b2-4b6b-beb2-44d212caa2a9}" BaseGUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}" FallbackId="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
     <Category Name="ACDCOverview" GUID="{c8887ac6-3c60-4209-9d69-8f4c12a60044}">
       <Color Name="NumberedListItemActive">
         <Background Type="CT_RAW" Source="FF1E1E2E" />
@@ -11330,5 +11330,58 @@
         <Foreground Type="CT_RAW" Source="FF0000FF" />
       </Color>
     </Category>
+
+    <!-- Visual Studio 2026 -->
+    <Category Name="Shell" GUID="{73708ded-2d56-4aad-b8eb-73b20d3f4bff}">
+      <Color Name="AccentFillDefault">
+        <Background Type="CT_RAW" Source="FF7287FD" /> <!-- Lavender -->
+      </Color>
+      <Color Name="AccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF7F8BCF" /> <!-- Lavender (Slightly Darkened) -->
+      </Color>
+      <Color Name="AccentFillTertiary">
+        <Background Type="CT_RAW" Source="CC9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="SolidBackgroundFillTertiary">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+      <Color Name="SolidBackgroundFillQuaternary">
+        <Background Type="CT_RAW" Source="FF1E1E2E" /> <!-- Base -->
+      </Color>
+      <Color Name="SurfaceBackgroundFillDefault">
+        <Background Type="CT_RAW" Source="FF11111B" /> <!-- Crust -->
+      </Color>
+      <Color Name="TextFillSecondary">
+        <Background Type="CT_RAW" Source="FFB4BEFE" /> <!-- Lavender -->
+      </Color>
+      <Color Name="TextFillPrimary">
+        <Background Type="CT_RAW" Source="FFCDD6F4" /> <!-- Text -->
+      </Color>
+      <Color Name="TextOnAccentFillPrimary">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+      <Color Name="TextOnAccentFillSecondary">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+    </Category>
+
+    <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
+      <Color Name="EnvironmentBackground">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+      <Color Name="EnvironmentBorder">
+        <Background Type="CT_RAW" Source="FFCBA6F7" /> <!-- Mauve -->
+      </Color>
+      <Color Name="EnvironmentIndicator">
+        <Background Type="CT_RAW" Source="66757575" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLogo">
+        <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
+      </Color>
+      <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+    </Category>
+    
   </Theme>
 </Themes>

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -2097,7 +2097,7 @@
         <Background Type="CT_RAW" Source="FF181825" />
       </Color>
       <Color Name="ComboBoxPopupBackgroundEnd">
-        <Background Type="CT_RAW" Source="FF181825" />
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
       </Color>
       <Color Name="DropDownBackground">
         <Background Type="CT_RAW" Source="FF181825" />
@@ -2621,7 +2621,7 @@
         <Background Type="CT_RAW" Source="66313244" />
       </Color>
       <Color Name="ScrollBarThumbPressedBackground">
-        <Background Type="CT_RAW" Source="66313244" />
+        <Background Type="CT_RAW" Source="FFCDD6F4" /> <!-- Text -->
       </Color>
       <Color Name="AutoHideResizeGrip">
         <Background Type="CT_RAW" Source="FF3A3C4E" />
@@ -3757,7 +3757,7 @@
         <Background Type="CT_RAW" Source="FF3D3D3D" />
       </Color>
       <Color Name="PageSideBarExpanderSeparator">
-        <Background Type="CT_RAW" Source="FF3D3D3D" />
+        <Background Type="CT_RAW" Source="FFB7BDf8" /> <!-- Lavender -->
       </Color>
       <Color Name="PageSideBarExpanderText">
         <Background Type="CT_RAW" Source="FFFAFAFA" />

--- a/Catppuccin VS Themes/Catppuccin Mocha.vstheme
+++ b/Catppuccin VS Themes/Catppuccin Mocha.vstheme
@@ -11363,6 +11363,9 @@
       <Color Name="TextOnAccentFillSecondary">
         <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
       </Color>
+      <Color Name="ControlFillDefault">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
     </Category>
 
     <Category Name="ShellInternal" GUID="{5af241b7-5627-4d12-bfb1-2b67d11127d7}">
@@ -11379,6 +11382,9 @@
         <Background Type="CT_RAW" Source="FF9184EE" /> <!-- Not Cat -->
       </Color>
       <Color Name="EnvironmentLayeredBackground">
+        <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
+      </Color>
+      <Color Name="ControlFillDefault">
         <Background Type="CT_RAW" Source="FF181825" /> <!-- Mantle -->
       </Color>
     </Category>

--- a/Catppuccin VS Themes/source.extension.vsixmanifest
+++ b/Catppuccin VS Themes/source.extension.vsixmanifest
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Catppuccin_for_Visual_Studio.cf093970-131b-4883-8405-0577339048c3" Version="1.6.3" Language="en-US" Publisher="Catppuccin" /> <!-- x-release-please-version -->
+        <Identity Id="Catppuccin_for_Visual_Studio.cf093970-131b-4883-8405-0577339048c3" Version="1.6.4" Language="en-US" Publisher="Catppuccin" />
+        <!-- x-release-please-version -->
         <DisplayName>Catppuccin for Visual Studio</DisplayName>
         <Description xml:space="preserve">Catppuccin Themes for Visual Studio</Description>
         <MoreInfo>https://github.com/djflan/Catppuccin-Visual-Studio-Themes</MoreInfo>


### PR DESCRIPTION
I've added the tokens to make the theme display properly in Visual Studio 2026. 

I don't think it's perfect but it is good enough to keep people happy before I can find the time to really fine tune the little bits that need finishing. 

I've kept a lot of comments in the file, but feel free to remove those if you don't want them. 